### PR TITLE
子模块目录切换至新的组织名

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "scheduler_code"]
 	path = scheduler_code
-	url = https://github.com/companyService/scheduler_code.git
+	url = https://github.com/InternetDataMiningLaboratory/scheduler_code.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 From companyservice/tornado
 MAINTAINER Jimin Huang "windworship2@163.com"
-RUN apt-get install python-pip -y \
+RUN apt-get update && apt-get install python-pip -y \
 && pip install docker-py python-consul
 RUN apt-get remove python-pip -y
 ADD scheduler_code /server


### PR DESCRIPTION
- .gitsubmodule中更改了组织名 证明可以更新子模块代码
